### PR TITLE
Add class importer module

### DIFF
--- a/module.json
+++ b/module.json
@@ -32,10 +32,12 @@
         ]
     },
     "esmodules": [
-        "./scripts/sbi.js"
+        "./scripts/sbi.js",
+        "./scripts/cbi.js"
     ],
     "styles": [
-        "./styles/sbi.css"
+        "./styles/sbi.css",
+        "./styles/cbi.css"
     ],
     "url": "https://github.com/Aioros/5e-statblock-importer",
     "manifest": "https://raw.githubusercontent.com/Aioros/5e-statblock-importer/main/module.json",

--- a/scripts/cbi.js
+++ b/scripts/cbi.js
@@ -1,0 +1,35 @@
+import { CBI_MODULE_NAME } from "./cbiConfig.js";
+import { registerSettings } from "./cbiConfig.js";
+import { cbiUtils } from "./cbiUtils.js";
+import { cbiWindow } from "./cbiWindow.js";
+import { cbiParser } from "./cbiParser.js";
+
+Hooks.on("init", () => {
+    registerSettings();
+    const parse = cbiParser.parseInput.bind(cbiParser);
+
+    // Extend the existing module API
+    const moduleApi = game.modules.get(CBI_MODULE_NAME).api || {};
+    moduleApi.parseClass = parse;
+    moduleApi.importClass = async (text, folderId) => {
+        return await parse(text).actor?.createClass5e(folderId);
+    };
+    game.modules.get(CBI_MODULE_NAME).api = moduleApi;
+});
+
+Hooks.on("renderItemDirectory", (app, html, data) => {
+    html = html instanceof jQuery ? html.get(0) : html;
+    let importButton = html.querySelector("#cbi-main-button");
+    if (game.user.hasPermission("ITEM_CREATE") && !importButton) {
+        cbiUtils.log("Rendering CBI button");
+        importButton = document.createElement("button");
+        importButton.id = "cbi-main-button";
+        importButton.setAttribute("type", "button")
+        importButton.innerHTML = `<i class="fas fa-file-import"></i>Import Class`;
+        importButton.addEventListener("click", () => {
+            cbiUtils.log("CBI button clicked");
+            cbiWindow.renderWindow();
+        });
+        html.querySelector(".directory-footer").appendChild(importButton);
+    }
+});

--- a/scripts/cbiActor.js
+++ b/scripts/cbiActor.js
@@ -1,0 +1,232 @@
+import { cbiUtils as cUtils } from "./cbiUtils.js";
+import { Blocks } from "./cbiData.js";
+import { CBI_MODULE_NAME } from "./cbiConfig.js";
+
+export class cbiActor {
+    #dnd5e = {};
+
+    constructor(name) {
+        this.name = name;                           // string
+        this.level = 1;                             // int
+        this.hitDie = null;                         // string (e.g., "1d8")
+        this.hitPoints = null;                      // RollData
+        this.proficiencyBonus = null;               // int
+        this.armorProficiencies = [];               // string[]
+        this.weaponProficiencies = [];              // string[]
+        this.toolProficiencies = [];                // string[]
+        this.savingThrows = [];                     // string[] (ability shortcuts)
+        this.skills = [];                           // string[] (skill shortcuts)
+        this.equipment = [];                        // string[]
+        this.classFeatures = [];                    // FeatureData[]
+        this.subclass = null;                       // string
+        this.subclassFeatures = [];                 // FeatureData[]
+        this.spellcastingAbility = null;            // string
+        this.spellSlots = null;                     // string or object
+        this.cantrips = [];                         // string[]
+        this.spells = [];                           // {name: string, level: int}[]
+        this.multiclassing = null;                  // string
+        this.otherInfo = null;                      // string
+        this.importIssues = {
+            missingSpells: [],
+            missingFeatures: [],
+        };
+    }
+
+    get actorData() {
+        return this.#dnd5e;
+    }
+
+    async updateActorData() {
+        this.setProficiencies();
+        this.setSavingThrows();
+        this.setSkills();
+        await this.setFeatures();
+        await this.setSpells();
+        this.setOtherInfo();
+    }
+
+    set5eProperty(path, value) {
+        return foundry.utils.setProperty(this.#dnd5e, path, value);
+    }
+
+    addItem(itemObject) {
+        if (typeof this.#dnd5e.items === "undefined") {
+            this.#dnd5e.items = [];
+        }
+        this.#dnd5e.items.push(itemObject);
+    }
+
+    enrichDescription(description) {
+        let enrichedDescription = description;
+
+        // Convert roll formulas to Foundry format
+        enrichedDescription = enrichedDescription.replace(/(\d+d\d+(\s?\+\s?\d+)?)/gi, "[[/r $1]]");
+
+        // Add enclosing paragraph if necessary
+        if (!enrichedDescription.startsWith("<p>")) {
+            enrichedDescription = "<p>" + enrichedDescription + "</p>";
+        }
+
+        return enrichedDescription;
+    }
+
+    setProficiencies() {
+        // Set armor proficiencies
+        if (this.armorProficiencies.length > 0) {
+            this.set5eProperty("system.traits.armorProf.value", this.armorProficiencies.map(a => a.toLowerCase()));
+        }
+
+        // Set weapon proficiencies
+        if (this.weaponProficiencies.length > 0) {
+            this.set5eProperty("system.traits.weaponProf.value", this.weaponProficiencies.map(w => w.toLowerCase()));
+        }
+
+        // Set tool proficiencies
+        if (this.toolProficiencies.length > 0) {
+            this.set5eProperty("system.traits.toolProf.value", this.toolProficiencies.map(t => t.toLowerCase()));
+        }
+    }
+
+    setSavingThrows() {
+        if (this.savingThrows.length > 0) {
+            for (const ability of this.savingThrows) {
+                this.set5eProperty(`system.abilities.${ability}.proficient`, 1);
+            }
+        }
+    }
+
+    setSkills() {
+        if (this.skills.length > 0) {
+            for (const skill of this.skills) {
+                this.set5eProperty(`system.skills.${skill}.proficient`, 1);
+            }
+        }
+    }
+
+    async setFeatures() {
+        // Add class features
+        for (const feature of this.classFeatures) {
+            await this.createFeatureItem(feature);
+        }
+
+        // Add subclass features
+        for (const feature of this.subclassFeatures) {
+            await this.createFeatureItem(feature, true);
+        }
+    }
+
+    async createFeatureItem(feature, isSubclass = false) {
+        const itemData = {};
+        itemData.name = cUtils.capitalizeAll(feature.name);
+        itemData.type = "feat";
+
+        const description = this.enrichDescription(feature.description);
+        foundry.utils.setProperty(itemData, "system.description.value", description);
+
+        // Set activation type for class features
+        foundry.utils.setProperty(itemData, "system.activation.type", "special");
+
+        // Set the feature requirement level
+        if (feature.level) {
+            foundry.utils.setProperty(itemData, "system.requirements", `${this.name} ${feature.level}`);
+        }
+
+        // Try to find matching image
+        const matchingImage = await cUtils.getImgFromPackItemAsync(itemData.name.toLowerCase(), "feat");
+        if (matchingImage) {
+            itemData.img = matchingImage;
+        }
+
+        this.addItem(itemData);
+    }
+
+    async setSpells() {
+        // Set spellcasting ability
+        if (this.spellcastingAbility) {
+            this.set5eProperty("system.spellcasting.ability", this.spellcastingAbility);
+        }
+
+        // Add cantrips
+        for (const cantripName of this.cantrips) {
+            await this.addSpellItem(cantripName, 0);
+        }
+
+        // Add spells
+        for (const spellData of this.spells) {
+            await this.addSpellItem(spellData.name, spellData.level);
+        }
+    }
+
+    async addSpellItem(spellName, level) {
+        const cleanName = spellName.trim();
+        const spellItem = await cUtils.getItemFromPacksAsync(cleanName, "spell");
+
+        if (spellItem) {
+            this.addItem(spellItem);
+        } else {
+            cUtils.warn(`Spell "${cleanName}" not found in compendiums`);
+            this.importIssues.missingSpells.push(cleanName);
+        }
+    }
+
+    setOtherInfo() {
+        if (this.otherInfo) {
+            const enriched = this.enrichDescription(this.otherInfo);
+            this.set5eProperty("system.description.value", enriched);
+        }
+
+        // Add class level info to biography
+        let bio = "";
+        if (this.level) {
+            bio += `<p><strong>Level:</strong> ${this.level}</p>`;
+        }
+        if (this.hitDie) {
+            bio += `<p><strong>Hit Die:</strong> ${this.hitDie}</p>`;
+        }
+        if (this.subclass) {
+            bio += `<p><strong>Subclass:</strong> ${this.subclass}</p>`;
+        }
+
+        if (bio) {
+            const currentBio = this.#dnd5e.system?.description?.value || "";
+            this.set5eProperty("system.description.value", currentBio + bio);
+        }
+    }
+
+    async createClass5e(folderId = null) {
+        this.set5eProperty("name", this.name);
+        this.set5eProperty("type", "class");
+
+        // Set hit die
+        if (this.hitDie) {
+            this.set5eProperty("system.hitDice", this.hitDie);
+        }
+
+        await this.updateActorData();
+
+        // Log the issues
+        if (this.importIssues.missingSpells.length > 0) {
+            cUtils.warn(`Missing spells: ${this.importIssues.missingSpells.join(", ")}`);
+        }
+
+        // Create the item
+        const itemData = {
+            name: this.name,
+            type: "class",
+            folder: folderId,
+            system: this.#dnd5e.system || {},
+            items: this.#dnd5e.items || []
+        };
+
+        cUtils.log("Creating class item", itemData);
+
+        try {
+            const createdItem = await Item.create(itemData);
+            cUtils.log(`Class "${this.name}" created successfully`);
+            return createdItem;
+        } catch (error) {
+            cUtils.error(`Failed to create class: ${error.message}`);
+            throw error;
+        }
+    }
+}

--- a/scripts/cbiConfig.js
+++ b/scripts/cbiConfig.js
@@ -1,0 +1,155 @@
+import sortablejs from '../lib/sortable.1.15.6.js';
+
+// Use the same module name as the main module
+export const CBI_MODULE_NAME = "5e-statblock-importer";
+
+export function registerSettings() {
+    game.settings.registerMenu(CBI_MODULE_NAME, "CompendiumOptionsMenu", {
+        name: "Compendium Options",
+        label: "Compendium Options",
+        hint: "Configure Compendium Priority for Spells and Items.",
+        icon: "fas fa-book",
+        type: CompendiumOptionsMenu,
+        restricted: false
+    });
+
+    game.settings.register(CBI_MODULE_NAME, "compendiums", {
+        name: "Compendiums",
+        scope: "client",
+        config: false,
+        type: Object,
+        default: {spells: [], items: []},
+    });
+
+    game.settings.register(CBI_MODULE_NAME, "debug", {
+        name: "Debug Mode",
+        scope: "client",
+        config: true,
+        type: Boolean,
+        default: false,
+    });
+}
+
+export function getPacks() {
+    const compendiumsSetting = game.settings.get(CBI_MODULE_NAME, "compendiums");
+
+    const compendiums = game.packs
+        .filter(p => p.documentName === "Item")
+        .map(p => ({ collection: p.collection, title: p.title }));
+    const spellCompendiums = compendiums
+        .map(p => {
+            const settingInfo = compendiumsSetting.spells.find(s => s.collection === p.collection);
+            const priority = settingInfo?.priority ?? 999;
+            let active = settingInfo?.active ?? false;
+            let disabled = false;
+            return { active, priority, disabled, ...p };
+        });
+    const srdCollection = game.settings.get("dnd5e", "rulesVersion") === "legacy" ? "dnd5e.spells" : "dnd5e.spells24";
+    // The appropriate one according to the rules setting will be locked as active.
+    let srd = spellCompendiums.find(p => p.collection === srdCollection);
+    if (!srd) {
+        // This happens in the interim, when the "spells24" one doesn't exist yet.
+        srd = spellCompendiums.find(p => p.collection === "dnd5e.spells");
+    }
+    srd.active = true;
+    srd.disabled = true;
+    spellCompendiums.sort((s1, s2) => {
+        if (s1.active === s2.active) return s1.priority - s2.priority;
+        if (s1.active) return -1;
+        return 1;
+    });
+    const itemCompendiums = compendiums
+        .map(p => {
+            const settingInfo = compendiumsSetting.items.find(s => s.collection === p.collection);
+            const priority = settingInfo?.priority ?? 999;
+            const active = settingInfo?.active ?? true;
+            return { active, priority, ...p };
+        })
+        .sort((s1, s2) => {
+            if (s1.active === s2.active) return s1.priority - s2.priority;
+            if (s1.active) return -1;
+            return 1;
+        });
+    return { spells: spellCompendiums, items: itemCompendiums };
+}
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+export class CompendiumOptionsMenu extends HandlebarsApplicationMixin(ApplicationV2) {
+
+    static DEFAULT_OPTIONS = {
+        tag: "form",
+        id: "cbi-compendium-options-menu",
+        position: { width: 700, height: 700 },
+        classes: ["cbi-options-menu"],
+        window: {
+            resizable: true,
+            title: "5e Class Importer - Compendium Options"
+        },
+        actions: {
+            confirm: this.confirm,
+            cancel: this.cancel
+        }
+    };
+
+    static PARTS = {
+        header: {
+            template: `modules/5e-statblock-importer/templates/cbiCompendiumOptionsHeader.hbs`
+        },
+        form: {
+            template: `modules/5e-statblock-importer/templates/cbiCompendiumOptions.hbs`,
+            scrollable: [""]
+        },
+        footer: {
+            template: `modules/5e-statblock-importer/templates/cbiCompendiumOptionsFooter.hbs`
+        }
+    }
+
+    _prepareContext(options) {
+        return {compendiums: getPacks()};
+    }
+
+    _onRender(context, options) {
+        const sortableOptions = {
+            animation: 150,
+        };
+        const spellCompendiumsList = document.getElementById("cbi-spell-compendiums");
+        const spellsSortable = sortablejs.create(spellCompendiumsList, sortableOptions);
+        const itemCompendiumsList = document.getElementById("cbi-item-compendiums");
+        const itemSortable = sortablejs.create(itemCompendiumsList, sortableOptions);
+    }
+
+    static confirm() {
+        let compendiums = {spells: [], items: []};
+        const spellsList = document.getElementById("cbi-spell-compendiums");
+        compendiums.spells = [...spellsList.querySelectorAll("input")]
+            .sort((s1, s2) => {
+                if (s1.checked === s2.checked) return 0;
+                if (s1.checked) return -1;
+                return 1;
+            })
+            .map((el, i) => ({
+                collection: el.getAttribute("data-id"),
+                active: el.checked,
+                priority: i
+            }));
+        const itemsList = document.getElementById("cbi-item-compendiums");
+        compendiums.items = [...itemsList.querySelectorAll("input")]
+            .sort((s1, s2) => {
+                if (s1.checked === s2.checked) return 0;
+                if (s1.checked) return -1;
+                return 1;
+            })
+            .map((el, i) => ({
+                collection: el.getAttribute("data-id"),
+                active: el.checked,
+                priority: i
+            }));
+        game.settings.set(CBI_MODULE_NAME, "compendiums", compendiums);
+        this.close();
+    }
+
+    static cancel() {
+        this.close();
+    }
+}

--- a/scripts/cbiData.js
+++ b/scripts/cbiData.js
@@ -1,0 +1,93 @@
+export const Blocks = {
+    name: {id: "name", name: "Class Name"},
+    level: {id: "level", name: "Level", top: true},
+    hitDie: {id: "hitDie", name: "Hit Die", top: true},
+    hitPoints: {id: "hitPoints", name: "Hit Points", top: true},
+    proficiencyBonus: {id: "proficiencyBonus", name: "Proficiency Bonus", top: true},
+    armorProficiencies: {id: "armorProficiencies", name: "Armor Proficiencies", top: true},
+    weaponProficiencies: {id: "weaponProficiencies", name: "Weapon Proficiencies", top: true},
+    toolProficiencies: {id: "toolProficiencies", name: "Tool Proficiencies", top: true},
+    savingThrows: {id: "savingThrows", name: "Saving Throw Proficiencies", top: true},
+    skills: {id: "skills", name: "Skill Proficiencies", top: true},
+    equipment: {id: "equipment", name: "Equipment", top: true},
+    classFeatures: {id: "classFeatures", name: "Class Features"},
+    subclass: {id: "subclass", name: "Subclass", top: true},
+    subclassFeatures: {id: "subclassFeatures", name: "Subclass Features"},
+    spellcasting: {id: "spellcasting", name: "Spellcasting"},
+    spellSlots: {id: "spellSlots", name: "Spell Slots", top: true},
+    cantrips: {id: "cantrips", name: "Cantrips"},
+    spells: {id: "spells", name: "Spells"},
+    multiclassing: {id: "multiclassing", name: "Multiclassing", top: true},
+    otherBlock: {id: "otherBlock", name: "Other (Description)"}
+}
+
+/*
+name: string
+value: object
+*/
+export class NameValueData {
+    constructor(name, value) {
+        this.name = name;
+        this.value = value;
+    }
+}
+
+/*
+level: int
+hitDie: string (e.g., "1d8")
+*/
+export class LevelData {
+    constructor(level, hitDie) {
+        this.level = level;
+        this.hitDie = hitDie;
+    }
+}
+
+/*
+value: int
+diceFormula: string
+*/
+export class RollData {
+    constructor(value, diceFormula) {
+        this.value = value;
+        this.formula = diceFormula;
+    }
+}
+
+/*
+name: string
+level: int
+description: string
+*/
+export class FeatureData {
+    constructor(name, level, description) {
+        this.name = name;
+        this.level = level;
+        this.description = description;
+    }
+}
+
+/*
+ability: string (e.g., "int", "wis", "cha")
+dc: int
+attackBonus: int
+*/
+export class SpellcastingData {
+    constructor(ability, dc, attackBonus) {
+        this.ability = ability;
+        this.dc = dc;
+        this.attackBonus = attackBonus;
+    }
+}
+
+export const KnownAbilities = [
+    "str", "dex", "con", "int", "wis", "cha"
+];
+
+export const KnownSkills = [
+    "acrobatics", "animal handling", "arcana", "athletics",
+    "deception", "history", "insight", "intimidation",
+    "investigation", "medicine", "nature", "perception",
+    "performance", "persuasion", "religion", "sleight of hand",
+    "stealth", "survival"
+];

--- a/scripts/cbiParser.js
+++ b/scripts/cbiParser.js
@@ -1,0 +1,304 @@
+import { cbiUtils as cUtils } from "./cbiUtils.js";
+import { cbiRegex as cRegex } from "./cbiRegex.js";
+import { cbiActor as cActor } from "./cbiActor.js";
+import { Blocks, NameValueData, RollData, FeatureData, LevelData, SpellcastingData } from "./cbiData.js";
+
+// Steps that the parser goes through:
+//  - Break text into well defined class parts
+//  - Create the Foundry data object from the parts
+
+export class cbiParser {
+
+    static actor;
+    static classBlocks;
+
+    static parseInput(text, hints = []) {
+        const lines = cUtils.stripMarkdownAndCleanInput(text).split("\n");
+
+        if (lines.length) {
+            // Assume the first line is the class name.
+            this.actor = new cActor(lines.shift().trim());
+
+            // Go through each line and group them by block type
+            this.classBlocks = new Map();
+            let lastBlockId = null;
+
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i].trim();
+
+                // Ignore empty lines
+                if (!line.length) {
+                    continue;
+                }
+
+                // Ignore lines starting with an asterisk
+                if (line.startsWith("*")) {
+                    continue;
+                }
+
+                let match = null;
+
+                // Check if there's a hint for this line
+                const hint = hints.find(h => h.text.trim() === line);
+                if (hint) {
+                    match = Blocks[hint.blockId];
+                } else {
+                    // Try to match against known block patterns
+                    match = cRegex.getFirstMatch(line);
+                }
+
+                // If we found a match, create a new block or add to existing
+                if (match) {
+                    lastBlockId = match.id;
+                    if (!this.classBlocks.has(lastBlockId)) {
+                        this.classBlocks.set(lastBlockId, []);
+                    }
+                }
+
+                // Add line to the current block
+                if (this.classBlocks.has(lastBlockId)) {
+                    this.classBlocks.get(lastBlockId).push({lineNumber: i, line, ...(hint && {hint: hint.blockId})});
+                }
+            }
+
+            // Process each block
+            for (let [blockId, blockData] of this.classBlocks.entries()) {
+                switch (blockId) {
+                    case Blocks.level.id:
+                        this.parseLevel(blockData);
+                        break;
+                    case Blocks.hitDie.id:
+                        this.parseHitDie(blockData);
+                        break;
+                    case Blocks.hitPoints.id:
+                        this.parseHitPoints(blockData);
+                        break;
+                    case Blocks.proficiencyBonus.id:
+                        this.parseProficiencyBonus(blockData);
+                        break;
+                    case Blocks.armorProficiencies.id:
+                        this.parseProficiencies(blockData, "armor");
+                        break;
+                    case Blocks.weaponProficiencies.id:
+                        this.parseProficiencies(blockData, "weapon");
+                        break;
+                    case Blocks.toolProficiencies.id:
+                        this.parseProficiencies(blockData, "tool");
+                        break;
+                    case Blocks.savingThrows.id:
+                        this.parseSavingThrows(blockData);
+                        break;
+                    case Blocks.skills.id:
+                        this.parseSkills(blockData);
+                        break;
+                    case Blocks.equipment.id:
+                        this.parseEquipment(blockData);
+                        break;
+                    case Blocks.classFeatures.id:
+                        this.parseFeatures(blockData, "class");
+                        break;
+                    case Blocks.subclass.id:
+                        this.parseSubclass(blockData);
+                        break;
+                    case Blocks.subclassFeatures.id:
+                        this.parseFeatures(blockData, "subclass");
+                        break;
+                    case Blocks.spellcasting.id:
+                        this.parseSpellcasting(blockData);
+                        break;
+                    case Blocks.spellSlots.id:
+                        this.parseSpellSlots(blockData);
+                        break;
+                    case Blocks.cantrips.id:
+                        this.parseCantrips(blockData);
+                        break;
+                    case Blocks.spells.id:
+                        this.parseSpells(blockData);
+                        break;
+                    case Blocks.multiclassing.id:
+                        this.parseMulticlassing(blockData);
+                        break;
+                    case Blocks.otherBlock.id:
+                        this.parseOther(blockData);
+                        break;
+                }
+            }
+
+            return this;
+        }
+    }
+
+    static parseLevel(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const match = text.match(cRegex.levelDetails);
+        if (match) {
+            this.actor.level = parseInt(match[1]);
+        }
+    }
+
+    static parseHitDie(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const match = text.match(cRegex.hitDieDetails);
+        if (match) {
+            this.actor.hitDie = match[1];
+        }
+    }
+
+    static parseHitPoints(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const match = text.match(cRegex.hitPointsDetails);
+        if (match) {
+            const value = parseInt(match[1]);
+            const formula = match[2] || this.actor.hitDie;
+            this.actor.hitPoints = new RollData(value, formula);
+        }
+    }
+
+    static parseProficiencyBonus(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const match = text.match(cRegex.proficiencyBonusDetails);
+        if (match) {
+            this.actor.proficiencyBonus = parseInt(match[1]);
+        }
+    }
+
+    static parseProficiencies(blockData, type) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        // Remove the header part
+        const cleaned = text.replace(/.+?:\s*/, '');
+        const proficiencies = cleaned.split(/[,;]/).map(p => p.trim()).filter(p => p);
+
+        if (type === "armor") {
+            this.actor.armorProficiencies = proficiencies;
+        } else if (type === "weapon") {
+            this.actor.weaponProficiencies = proficiencies;
+        } else if (type === "tool") {
+            this.actor.toolProficiencies = proficiencies;
+        }
+    }
+
+    static parseSavingThrows(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const matches = text.matchAll(cRegex.abilityPattern);
+        const abilities = [];
+        for (const match of matches) {
+            abilities.push(cUtils.convertToShortAbility(match[1]));
+        }
+        this.actor.savingThrows = [...new Set(abilities)]; // Remove duplicates
+    }
+
+    static parseSkills(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const matches = text.matchAll(cRegex.skillPattern);
+        const skills = [];
+        for (const match of matches) {
+            skills.push(cUtils.convertToShortSkill(match[1]));
+        }
+        this.actor.skills = [...new Set(skills)]; // Remove duplicates
+    }
+
+    static parseEquipment(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        // Remove the header
+        const cleaned = text.replace(/.+?:\s*/, '');
+        this.actor.equipment = cleaned.split(/[•\n]/).map(e => e.trim()).filter(e => e);
+    }
+
+    static parseFeatures(blockData, type) {
+        const features = [];
+        let currentFeature = null;
+
+        for (const lineData of blockData) {
+            const line = lineData.line;
+
+            // Check if this line is a feature title
+            const titleMatch = line.match(cRegex.featureTitle);
+            if (titleMatch && cUtils.startsWithCapital(line)) {
+                // Save the previous feature if any
+                if (currentFeature) {
+                    features.push(currentFeature);
+                }
+
+                // Start a new feature
+                const name = titleMatch[1].trim();
+                const level = titleMatch[2] ? parseInt(titleMatch[2]) : this.actor.level || 1;
+                currentFeature = new FeatureData(name, level, "");
+            } else if (currentFeature) {
+                // Add to the current feature's description
+                currentFeature.description += (currentFeature.description ? " " : "") + line;
+            }
+        }
+
+        // Don't forget the last feature
+        if (currentFeature) {
+            features.push(currentFeature);
+        }
+
+        if (type === "class") {
+            this.actor.classFeatures = features;
+        } else if (type === "subclass") {
+            this.actor.subclassFeatures = features;
+        }
+    }
+
+    static parseSubclass(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const cleaned = text.replace(/.+?:\s*/, '');
+        this.actor.subclass = cleaned.trim();
+    }
+
+    static parseSpellcasting(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const abilityMatch = text.match(cRegex.spellcastingAbility);
+        if (abilityMatch) {
+            const ability = cUtils.convertToShortAbility(abilityMatch[1]);
+            this.actor.spellcastingAbility = ability;
+        }
+    }
+
+    static parseSpellSlots(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        // This is a simplified parser - could be expanded for full spell slot tables
+        this.actor.spellSlots = text;
+    }
+
+    static parseCantrips(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        const spells = text.split(/[,;•\n]/).map(s => s.trim()).filter(s => s && !s.match(/cantrip/i));
+        this.actor.cantrips = spells;
+    }
+
+    static parseSpells(blockData) {
+        const spells = [];
+        let currentLevel = 0;
+
+        for (const lineData of blockData) {
+            const line = lineData.line;
+
+            // Check for spell level
+            const levelMatch = line.match(cRegex.spellLevelPattern);
+            if (levelMatch) {
+                currentLevel = parseInt(levelMatch[1]);
+                continue;
+            }
+
+            // Parse spells from this line
+            const spellNames = line.split(/[,;•]/).map(s => s.trim()).filter(s => s);
+            for (const spellName of spellNames) {
+                spells.push({name: spellName, level: currentLevel});
+            }
+        }
+
+        this.actor.spells = spells;
+    }
+
+    static parseMulticlassing(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        this.actor.multiclassing = text;
+    }
+
+    static parseOther(blockData) {
+        const text = cUtils.combineToString(blockData.map(l => l.line));
+        this.actor.otherInfo = text;
+    }
+}

--- a/scripts/cbiRegex.js
+++ b/scripts/cbiRegex.js
@@ -1,0 +1,134 @@
+import { Blocks } from "./cbiData.js";
+
+export class cbiRegex {
+    // Block header patterns - identify which section a line belongs to
+    static levelHeader = /^(level|class level|lvl)[:\s]/i;
+    static hitDieHeader = /^(hit die|hit dice|hd)[:\s]/i;
+    static hitPointsHeader = /^(hit points|hp|health)[:\s]/i;
+    static proficiencyBonusHeader = /^(proficiency bonus|prof bonus|pb)[:\s]/i;
+    static armorProficienciesHeader = /^(armor proficienc(y|ies))[:\s]/i;
+    static weaponProficienciesHeader = /^(weapon proficienc(y|ies))[:\s]/i;
+    static toolProficienciesHeader = /^(tool proficienc(y|ies))[:\s]/i;
+    static savingThrowsHeader = /^(saving throw(s)?( proficienc(y|ies))?)[:\s]/i;
+    static skillsHeader = /^(skill(s)?( proficienc(y|ies))?)[:\s]/i;
+    static equipmentHeader = /^(equipment|starting equipment)[:\s]/i;
+    static classFeaturesHeader = /^(class features?|features?)[:\s]/i;
+    static subclassHeader = /^(subclass|archetype|path|tradition|patron|domain|circle)[:\s]/i;
+    static subclassFeaturesHeader = /^(subclass features?|archetype features?)[:\s]/i;
+    static spellcastingHeader = /^(spellcasting|magic)[:\s]/i;
+    static spellSlotsHeader = /^(spell slots?)[:\s]/i;
+    static cantripsHeader = /^(cantrips?( known)?)[:\s]/i;
+    static spellsHeader = /^(spells?( known)?|prepared spells?)[:\s]/i;
+    static multiclassingHeader = /^(multiclassing)[:\s]/i;
+
+    // Data extraction patterns
+    static levelDetails = /(?:level|lvl)\s*(\d+)/i;
+    static hitDieDetails = /(\d+d\d+)/i;
+    static hitPointsDetails = /(\d+)\s*(?:\+\s*(.+))?/;
+    static proficiencyBonusDetails = /\+?(\d+)/;
+
+    // Feature pattern - matches "Feature Name (Level X)" or "Feature Name"
+    static featureTitle = /^([^(]+?)(?:\s*\((?:level\s*)?(\d+)\))?$/i;
+
+    // Ability pattern - matches ability names
+    static abilityPattern = /(strength|dexterity|constitution|intelligence|wisdom|charisma|str|dex|con|int|wis|cha)/gi;
+
+    // Skill pattern - matches skill names
+    static skillPattern = /(acrobatics|animal handling|arcana|athletics|deception|history|insight|intimidation|investigation|medicine|nature|perception|performance|persuasion|religion|sleight of hand|stealth|survival)/gi;
+
+    // Spellcasting ability pattern
+    static spellcastingAbility = /(?:spellcasting ability|spell save dc|spell attack)[^.]*?(strength|dexterity|constitution|intelligence|wisdom|charisma|str|dex|con|int|wis|cha)/i;
+
+    // Spell level pattern - matches "1st level", "2nd level", etc.
+    static spellLevelPattern = /(\d+)(?:st|nd|rd|th)\s*level/i;
+
+    // Cantrip pattern
+    static cantripPattern = /cantrip/i;
+
+    // Pure block header - a line that ends with a colon and has data on the next line
+    static pureBlockHeader = /^[^:]+:\s*$/;
+
+    /**
+     * Returns the first block that matches the given line
+     * @param {string} line - The line to test
+     * @returns {object|null} - The matching block or null
+     */
+    static getFirstMatch(line) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) return null;
+
+        // Check each block header pattern
+        if (this.levelHeader.test(trimmedLine)) return Blocks.level;
+        if (this.hitDieHeader.test(trimmedLine)) return Blocks.hitDie;
+        if (this.hitPointsHeader.test(trimmedLine)) return Blocks.hitPoints;
+        if (this.proficiencyBonusHeader.test(trimmedLine)) return Blocks.proficiencyBonus;
+        if (this.armorProficienciesHeader.test(trimmedLine)) return Blocks.armorProficiencies;
+        if (this.weaponProficienciesHeader.test(trimmedLine)) return Blocks.weaponProficiencies;
+        if (this.toolProficienciesHeader.test(trimmedLine)) return Blocks.toolProficiencies;
+        if (this.savingThrowsHeader.test(trimmedLine)) return Blocks.savingThrows;
+        if (this.skillsHeader.test(trimmedLine)) return Blocks.skills;
+        if (this.equipmentHeader.test(trimmedLine)) return Blocks.equipment;
+        if (this.classFeaturesHeader.test(trimmedLine)) return Blocks.classFeatures;
+        if (this.subclassHeader.test(trimmedLine)) return Blocks.subclass;
+        if (this.subclassFeaturesHeader.test(trimmedLine)) return Blocks.subclassFeatures;
+        if (this.spellcastingHeader.test(trimmedLine)) return Blocks.spellcasting;
+        if (this.spellSlotsHeader.test(trimmedLine)) return Blocks.spellSlots;
+        if (this.cantripsHeader.test(trimmedLine)) return Blocks.cantrips;
+        if (this.spellsHeader.test(trimmedLine)) return Blocks.spells;
+        if (this.multiclassingHeader.test(trimmedLine)) return Blocks.multiclassing;
+
+        return null;
+    }
+
+    /**
+     * Tests if a line matches a specific block pattern
+     * @param {string} line - The line to test
+     * @param {object} block - The block to test against
+     * @returns {boolean} - True if the line matches the block
+     */
+    static testBlock(line, block) {
+        if (!block) return false;
+        const trimmedLine = line.trim();
+
+        switch (block.id) {
+            case Blocks.level.id:
+                return this.levelHeader.test(trimmedLine);
+            case Blocks.hitDie.id:
+                return this.hitDieHeader.test(trimmedLine);
+            case Blocks.hitPoints.id:
+                return this.hitPointsHeader.test(trimmedLine);
+            case Blocks.proficiencyBonus.id:
+                return this.proficiencyBonusHeader.test(trimmedLine);
+            case Blocks.armorProficiencies.id:
+                return this.armorProficienciesHeader.test(trimmedLine);
+            case Blocks.weaponProficiencies.id:
+                return this.weaponProficienciesHeader.test(trimmedLine);
+            case Blocks.toolProficiencies.id:
+                return this.toolProficienciesHeader.test(trimmedLine);
+            case Blocks.savingThrows.id:
+                return this.savingThrowsHeader.test(trimmedLine);
+            case Blocks.skills.id:
+                return this.skillsHeader.test(trimmedLine);
+            case Blocks.equipment.id:
+                return this.equipmentHeader.test(trimmedLine);
+            case Blocks.classFeatures.id:
+                return this.classFeaturesHeader.test(trimmedLine);
+            case Blocks.subclass.id:
+                return this.subclassHeader.test(trimmedLine);
+            case Blocks.subclassFeatures.id:
+                return this.subclassFeaturesHeader.test(trimmedLine);
+            case Blocks.spellcasting.id:
+                return this.spellcastingHeader.test(trimmedLine);
+            case Blocks.spellSlots.id:
+                return this.spellSlotsHeader.test(trimmedLine);
+            case Blocks.cantrips.id:
+                return this.cantripsHeader.test(trimmedLine);
+            case Blocks.spells.id:
+                return this.spellsHeader.test(trimmedLine);
+            case Blocks.multiclassing.id:
+                return this.multiclassingHeader.test(trimmedLine);
+            default:
+                return false;
+        }
+    }
+}

--- a/scripts/cbiUtils.js
+++ b/scripts/cbiUtils.js
@@ -1,0 +1,385 @@
+import { getPacks, CBI_MODULE_NAME } from "./cbiConfig.js";
+
+const logPrefix = "5e Class Importer |";
+
+export class cbiUtils {
+
+    static notify(type, message, ...objects) {
+        let consoleMethod = type === "info" ? "log" : type;
+        if (type !== "info" || game.settings.get(CBI_MODULE_NAME, "debug")) {
+            ui.notifications[type](logPrefix + " " + message);
+            if (objects.length) {
+                console[consoleMethod](logPrefix, ...objects);
+            }
+        }
+    }
+
+    static log(message, ...objects) {
+        this.notify("info", message, ...objects);
+    }
+
+    static warn(message, ...objects) {
+        this.notify("warn", message, ...objects);
+    }
+
+    static error(message, ...objects) {
+        this.notify("error", message, ...objects);
+    }
+
+    static stripMarkdownAndCleanInput(text) {
+        const domParser = new DOMParser();
+        const showdownConverter = new showdown.Converter();
+        const html = domParser.parseFromString(showdownConverter.makeHtml(text), "text/html");
+        return html.body.innerText
+            .split(/[\n\r]+/g)
+            .map(str => str.trim())
+            .map(str => str.replace("::", "")) // remove some Homebrewery markdown
+            .map(str => str.replace(/\s+/g, " ")) // remove double spaces
+            .filter(str => !str.startsWith("{{") && !str.startsWith("}}") && str !== ":") // remove some other Homebrewery markdown
+            .filter(str => str) // remove empty lines
+            .join("\n");
+    }
+
+    static getAbilityMod(abilityValue = 10) {
+        return Math.floor((abilityValue - 10) / 2);
+    }
+
+    static getProficiencyBonus(level) {
+        return Math.max(2, 2 + Math.floor((level - 1) / 4));
+    }
+
+    static getMinLevel(proficiencyBonus) {
+        return proficiencyBonus * 4 - 7;
+    }
+
+    static convertToShortAbility(abilityName) {
+        const ability = abilityName.toLowerCase();
+
+        switch (ability) {
+            case "strength":
+                return "str";
+            case "dexterity":
+                return "dex";
+            case "constitution":
+                return "con";
+            case "intelligence":
+                return "int";
+            case "wisdom":
+                return "wis";
+            case "charisma":
+                return "cha";
+            default:
+                return ability;
+        }
+    }
+
+    static convertToShortSkill(skillName) {
+        const skill = skillName.toLowerCase();
+
+        switch (skill) {
+            case "acrobatics":
+                return "acr";
+            case "animal handling":
+                return "ani";
+            case "arcana":
+                return "arc";
+            case "athletics":
+                return "ath";
+            case "deception":
+                return "dec";
+            case "history":
+                return "his";
+            case "insight":
+                return "ins";
+            case "intimidation":
+                return "itm";
+            case "investigation":
+                return "inv";
+            case "medicine":
+                return "med";
+            case "nature":
+                return "nat";
+            case "perception":
+                return "prc";
+            case "performance":
+                return "prf";
+            case "persuasion":
+                return "per";
+            case "religion":
+                return "rel";
+            case "sleight of hand":
+                return "slt";
+            case "stealth":
+                return "ste";
+            case "survival":
+                return "sur";
+            default:
+                return skill;
+        }
+    }
+
+    // Search all compendiums and get just the icon from the item, if found.
+    static async getImgFromPackItemAsync(itemName, type) {
+        let result = null;
+        const item = await this.getItemFromPacksAsync(itemName, type);
+
+        if (item) {
+            result = item.img;
+        }
+
+        return result;
+    }
+
+    static async getItemFromPacksAsync(itemName, type) {
+        let result = null;
+
+        const packs = getPacks()[type === "spell" ? "spells" : "items"].filter(p => p.active);
+
+        for (const pack of packs) {
+            result = await this.getItemFromPackAsync(game.packs.get(pack.collection), itemName);
+
+            if (result && (!type || result.type === type)) {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    static async getItemFromPackAsync(pack, itemName) {
+        let result = null;
+        const normalizedName = itemName.toLowerCase().replace(/[^a-zA-Z0-9]/g, "_");
+        const item = pack.index.find(e => normalizedName === e.name.toLowerCase().replace(/[^a-zA-Z0-9]/g, "_"));
+
+        if (item) {
+            const itemDoc = await pack.getDocument(item._id);
+            result = itemDoc.toObject();
+            result.sourceUuid = itemDoc.uuid;
+        }
+
+        return result;
+    }
+
+    // ==========================
+    // String Functions
+    // ==========================
+    // camelToTitleCase("legendaryActions") => "Legendary Actions"
+    static camelToTitleCase(string) {
+        return string// insert a space before all caps
+            .replace(/([A-Z])/g, ' $1')
+            // uppercase the first character
+            .replace(/^./, function (str) { return str.toUpperCase(); })
+    }
+
+    // capitalizeAll("passive perception") => "Passive Perception"
+    static capitalizeAll(string) {
+        if (!string) {
+            return null;
+        }
+
+        return string.toLowerCase().replace(/^\w|\s\w|\(\w/g, function (letter) {
+            return letter.toUpperCase();
+        })
+    }
+
+    static camelToTitleUpperIfTwoLetters(string) {
+        return this.camelToTitleCase(string).split(" ").map(w => (w.length == 2 && w !== "To") ? w.toUpperCase() : w).join(" ");
+    }
+
+    // capitalizeFirstLetter("passive perception") => "Passive perception"
+    static capitalizeFirstLetter(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
+    }
+
+    // format("{0} comes before {1}", "a", "b") => "a comes before b"
+    static format(stringToFormat, ...tokens) {
+        return stringToFormat.replace(/{(\d+)}/g, function (match, number) {
+            return typeof tokens[number] != 'undefined' ? tokens[number] : match;
+        });
+    };
+
+    // startsWithCapital("Foo") => true
+    static startsWithCapital(string) {
+        return /[A-Z]/.test(string.charAt(0))
+    }
+
+    // parseFraction("1/2") => 0.5
+    static parseFraction(string) {
+        let result = null;
+        const numbers = string.split("/");
+
+        if (numbers.length == 2) {
+            const numerator = parseFloat(numbers[0]);
+            const denominator = parseFloat(numbers[1]);
+            result = numerator / denominator;
+        }
+
+        return result;
+    }
+
+    static exactMatch(string, regex) {
+        const match = string.match(regex);
+        return match && match[0] === string;
+    }
+
+    static replaceAt(string, index, char) {
+        if (index > string.length - 1) return string;
+        return string.substring(0, index) + char + string.substring(index + 1);
+    }
+
+    static trimStringEnd(string, trimString) {
+        let result = string;
+
+        if (string.endsWith(trimString)) {
+            result = string.substr(0, string.length - trimString.length);
+        }
+
+        return result;
+    }
+
+    // Given an array of strings, returns one string.
+    static combineToString(strings) {
+        return strings.join("\n");
+    }
+
+    // Given an array of source lines, combine their text and remove the action/feature name from the start
+    static combineSourceLines(lines, removeName = true) {
+        let combined = this.combineToString(lines.map(l => l.line))
+            .replace("\n", " ");
+        if (removeName) {
+            combined = combined.replace(/^[^.:!]*[.:!]\s*/i, "");
+        }
+        return combined;
+    }
+
+    // ==========================
+    // Array Functions
+    // ==========================
+
+    // last([1,2,3]) => 3
+    static last(array) {
+        return array[array.length - 1];
+    }
+
+    // skipWhile([1,2,3], (item) => item !== 2) => [2,3]
+    static skipWhile(array, callback) {
+        let doneSkipping = false;
+
+        return array.filter((item) => {
+            if (!doneSkipping) {
+                doneSkipping = !callback(item);
+            }
+
+            return doneSkipping;
+        });
+    };
+
+    // intersect([1,2,3], [2]) => [2]
+    static intersect(sourceArr, targetArr) {
+        return sourceArr.filter(item => targetArr.indexOf(item) !== -1);
+    };
+
+    // except([1,2,3], [2]) => [1,3]
+    static except(sourceArr, targetArr) {
+        return sourceArr.filter(item => targetArr.indexOf(item) === -1);
+    };
+
+    // =======================
+    // ContentEditable Helpers
+    // =======================
+
+    static textNodesUnder(node) {
+        const all = [];
+        for (node = node.firstChild; node; node = node.nextSibling) {
+            if (node.nodeType === 3) {
+                all.push(node);
+            } else {
+                all.push(...this.textNodesUnder(node));
+            }
+        }
+        return all;
+    }
+
+    static getCaretPositionFromOffsetInfo(contentEditable, offsetInfo = {}) {
+        let index = 0;
+        let currentLine = -1;
+
+        if (offsetInfo.node === contentEditable && offsetInfo.offset === 0) {
+            return 0;
+        }
+
+        const textNodes = this.textNodesUnder(contentEditable);
+
+        for (let i=0; i<textNodes.length; i++) {
+            const node = textNodes[i];
+            const nodeLine = node.parentNode.closest(".line-container")?.getAttribute("data-line");
+            if (nodeLine && parseInt(nodeLine) !== currentLine) {
+                index++;
+                currentLine = parseInt(nodeLine);
+            }
+            const isSelectedNode = node === offsetInfo.node;
+
+            if (isSelectedNode) {
+                index += offsetInfo.offset;
+                break;
+            } else {
+                index += node.textContent.length;
+            }
+        }
+
+        return index;
+    }
+
+    static getSelectionRange(contentEditable) {
+        const selection = window.getSelection();
+        return {
+            start: this.getCaretPositionFromOffsetInfo(contentEditable, {node: selection.anchorNode, offset: selection.anchorOffset}),
+            end: this.getCaretPositionFromOffsetInfo(contentEditable, {node: selection.focusNode, offset: selection.focusOffset})
+        };
+    }
+
+    static getOffsetInfoFromCaretPosition(contentEditable, position) {
+        let cumulativeIndex = 0;
+        let relativeIndex = 0;
+        let targetNode = null;
+
+        const textNodes = this.textNodesUnder(contentEditable);
+
+        for (let i=0; i<textNodes.length; i++) {
+            const node = textNodes[i];
+
+            if (position <= cumulativeIndex + node.textContent.length) {
+                targetNode = node;
+                relativeIndex = position - cumulativeIndex;
+                break;
+            }
+
+            cumulativeIndex += node.textContent.length;
+        }
+
+        return {node: targetNode || contentEditable, offset: relativeIndex};
+    }
+
+    static setSelectionRange(contentEditable, rangeInfo) {
+        const anchorInfo = this.getOffsetInfoFromCaretPosition(contentEditable, rangeInfo.start);
+        const focusInfo = this.getOffsetInfoFromCaretPosition(contentEditable, rangeInfo.end);
+
+        const range = window.document.createRange();
+        range.setStart(anchorInfo.node, anchorInfo.offset);
+        range.setEnd(focusInfo.node, focusInfo.offset);
+
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+    }
+
+    static insertTextAtSelection(txt) {
+        const selectedRange = window.getSelection()?.getRangeAt(0);
+        if (!selectedRange || !txt) {
+            return;
+        }
+        selectedRange.deleteContents();
+        selectedRange.insertNode(document.createTextNode(txt));
+        selectedRange.setStart(selectedRange.endContainer, selectedRange.endOffset);
+    }
+}

--- a/scripts/cbiWindow.js
+++ b/scripts/cbiWindow.js
@@ -1,0 +1,290 @@
+import { cbiUtils } from "./cbiUtils.js";
+import { cbiParser } from "./cbiParser.js";
+import { CBI_MODULE_NAME, CompendiumOptionsMenu } from "./cbiConfig.js";
+import { Blocks } from "./cbiData.js";
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+export class cbiWindow extends HandlebarsApplicationMixin(ApplicationV2) {
+
+    constructor(options) {
+        super(options);
+        this.keyupParseTimeout = null;
+        this.pauseAutoParse = false;
+    }
+
+    static DEFAULT_OPTIONS = {
+        id: "cbi-window",
+        position: { width: 800, height: 640 },
+        classes: ["cbi-window"],
+        window: {
+            resizable: true,
+            title: "5e Class Importer"
+        },
+        actions: {
+            parse: cbiWindow.parse,
+            reset: cbiWindow.reset,
+            import: cbiWindow.import,
+            compendiumOptions: cbiWindow.openCompendiumOptions,
+        }
+    };
+
+    static PARTS = {
+        form: {
+            template: `modules/5e-statblock-importer/templates/cbiWindow.hbs`
+        }
+    };
+
+    static openCompendiumOptions() {
+        const menu = new CompendiumOptionsMenu();
+        menu.render(true);
+    }
+
+    static cbiInputWindowInstance = {};
+
+    static async renderWindow() {
+        cbiWindow.cbiInputWindowInstance = new cbiWindow();
+        cbiWindow.cbiInputWindowInstance.render(true);
+    }
+
+    _onRender(context, options) {
+        const input = document.getElementById("cbi-input");
+
+        input.addEventListener("keydown", e => {
+            const selectionRange = cbiUtils.getSelectionRange(input);
+
+            input.querySelectorAll(".line-container > span").forEach(l => {
+                const hint = l.closest(".line-container").getAttribute("data-hint");
+                if (hint) {
+                    l.setAttribute("data-hint", hint);
+                }
+                if (!l.classList.contains("hint")) {
+                    input.appendChild(l);
+                    input.innerHTML += "\n";
+                }
+            });
+            input.querySelectorAll(".block-container").forEach(b => {
+                input.removeChild(b);
+            });
+
+            cbiUtils.setSelectionRange(input, selectionRange);
+
+            // Override pressing enter in contenteditable
+            if (e.key == "Enter") {
+                // Don't automatically put in divs
+                e.preventDefault();
+                e.stopPropagation();
+                // Insert newline
+                cbiUtils.insertTextAtSelection("\n");
+            }
+            input.dispatchEvent(new Event("input"));
+        });
+
+        input.addEventListener("paste", e => {
+            // Cancel paste
+            e.preventDefault();
+            // Get plaintext from clipboard
+            let text = (e.originalEvent || e).clipboardData.getData("text/plain");
+            // Remove unicode format control characters
+            text = text.replace(/\p{Cf}/gu, "");
+            // Insert text manually
+            cbiUtils.insertTextAtSelection(text);
+        });
+
+        const folderSelect = document.getElementById("cbi-import-select");
+
+        // Add a default option
+        folderSelect.add(new Option("None", ""));
+
+        const itemFolders = [...game.folders]
+            .filter(f => f.type === "Item")
+            .map(f => ({ "name": f.name, "id": f._id }));
+
+        // Add the available folders
+        for (const folder of itemFolders) {
+            folderSelect.add(new Option(folder.name, folder.id));
+        }
+
+        ["blur", "input", "paste"].forEach(eventType => {
+            input.addEventListener(eventType, (e) => {
+                if (document.getElementById("cbi-import-autoparse").checked && !this.pauseAutoParse) {
+                    if (this.keyupParseTimeout) clearTimeout(this.keyupParseTimeout);
+                    this.keyupParseTimeout = setTimeout(cbiWindow.parse, e.type == "input" ? 1000 : 0);
+                }
+            });
+        });
+
+        cbiUtils.log("Listeners activated");
+    }
+
+    static getBlockSelectInputGroup(selected) {
+        const fields = foundry.applications.fields;
+
+        const blockSelect = fields.createSelectInput({
+            name: "hint",
+            options: Object.values(Blocks),
+            blank: "None",
+            valueAttr: "id",
+            labelAttr: "name",
+            localize: false,
+            value: selected
+        });
+        const blockGroup = fields.createFormGroup({
+            input: blockSelect,
+            label: "Hint Block",
+            hint: "Select the block that this line should belong to."
+        });
+        const content = blockGroup.outerHTML;
+        return content;
+    }
+
+    static hintDialog(lineElement) {
+        cbiWindow.cbiInputWindowInstance.pauseAutoParse = true;
+
+        const lineText = lineElement.innerText;
+        const content = `<q class="line-text">${lineText}</q>` + cbiWindow.getBlockSelectInputGroup(lineElement.getAttribute("data-hint"));
+
+        foundry.applications.api.DialogV2.prompt({
+            window: { title: "Line Hint" },
+            position: { width: 400 },
+            classes: ["cbi-dialog"],
+            modal: true,
+            rejectClose: false,
+            content,
+            ok: {
+                callback: (event, button, dialog) => new FormDataExtended(button.form).object
+            }
+        }).then(hint => {
+            if (hint) {
+                hint = hint.hint;
+                cbiWindow.cbiInputWindowInstance.pauseAutoParse = false;
+                if (!hint) {
+                    lineElement.removeAttribute("data-hint");
+                    lineElement.querySelector(".hint").remove?.();
+                } else {
+                    lineElement.setAttribute("data-hint", hint);
+                    lineElement.querySelector(".hint")?.setAttribute("data-block-id", hint);
+                    lineElement.querySelector(".hint")?.setAttribute("data-block-name", Blocks[hint].name);
+                }
+                cbiWindow.parse();
+            }
+        });
+    }
+
+    static parse() {
+        const input = document.getElementById("cbi-input");
+
+        if (!input.innerText.trim().length) return;
+
+        const hints = [...input.querySelectorAll("[data-hint]")].map(l => ({text: l.innerText, blockId: l.getAttribute("data-hint")}));
+
+        try {
+            const parser = cbiParser.parseInput(input.innerText, hints);
+            const { actor, classBlocks } = parser || {};
+
+            if (!classBlocks || !classBlocks.size) {
+                cbiUtils.error("Unable to parse class data");
+                return {};
+            }
+
+            cbiUtils.log("Parsing completed", classBlocks, actor);
+
+            // Create line display
+            const lines = input.innerText.split("\n");
+            let divLines = lines.map((line, i) => {
+                const block = [...classBlocks.entries()].find(e => e[1].some(l => l.lineNumber == i))?.[0];
+                const spanLine = document.createElement("span");
+                spanLine.innerText = line;
+                return { blockId: block, line: spanLine };
+            });
+
+            // Group lines by block
+            const blocks = new Map();
+            for (const divLine of divLines) {
+                if (!blocks.has(divLine.blockId)) {
+                    blocks.set(divLine.blockId, []);
+                }
+                blocks.get(divLine.blockId).push(divLine.line);
+            }
+
+            // Clear and rebuild input display
+            input.innerHTML = "";
+
+            for (const [blockId, lines] of blocks) {
+                const blockContainer = document.createElement("div");
+                blockContainer.classList.add("block-container");
+                blockContainer.setAttribute("data-block-id", blockId);
+                blockContainer.setAttribute("data-block-name", Blocks[blockId]?.name || "Unknown");
+
+                for (let i = 0; i < lines.length; i++) {
+                    const lineContainer = document.createElement("div");
+                    lineContainer.classList.add("line-container");
+                    lineContainer.setAttribute("data-line", i);
+
+                    lineContainer.appendChild(lines[i]);
+                    blockContainer.appendChild(lineContainer);
+                }
+
+                input.appendChild(blockContainer);
+            }
+
+            // Display any issues
+            const issuesSection = document.getElementById("cbi-issues");
+            issuesSection.innerHTML = "";
+
+            if (actor.importIssues.missingSpells.length > 0) {
+                const issueDiv = document.createElement("div");
+                issueDiv.classList.add("cbi-issue");
+                issueDiv.innerHTML = `<strong>Missing spells:</strong> ${actor.importIssues.missingSpells.join(", ")}`;
+                issuesSection.appendChild(issueDiv);
+            }
+
+            return parser;
+        } catch (error) {
+            cbiUtils.error("Parse error: " + error.message);
+            console.error(error);
+            return {};
+        }
+    }
+
+    static reset() {
+        const input = document.getElementById("cbi-input");
+        input.innerHTML = "";
+
+        const issuesSection = document.getElementById("cbi-issues");
+        issuesSection.innerHTML = "";
+
+        cbiUtils.log("Input reset");
+    }
+
+    static async import() {
+        const input = document.getElementById("cbi-input");
+        const folderSelect = document.getElementById("cbi-import-select");
+        const folderId = folderSelect.value || null;
+
+        if (!input.innerText.trim().length) {
+            cbiUtils.warn("No input to import");
+            return;
+        }
+
+        try {
+            const hints = [...input.querySelectorAll("[data-hint]")].map(l => ({text: l.innerText, blockId: l.getAttribute("data-hint")}));
+            const parser = cbiParser.parseInput(input.innerText, hints);
+
+            if (!parser || !parser.actor) {
+                cbiUtils.error("Failed to parse class data");
+                return;
+            }
+
+            const createdClass = await parser.actor.createClass5e(folderId);
+
+            if (createdClass) {
+                cbiUtils.log(`Class "${parser.actor.name}" imported successfully`);
+                ui.notifications.info(`Class "${parser.actor.name}" created successfully`);
+            }
+        } catch (error) {
+            cbiUtils.error("Import failed: " + error.message);
+            console.error(error);
+        }
+    }
+}

--- a/styles/cbi.css
+++ b/styles/cbi.css
@@ -1,0 +1,175 @@
+body {
+    --matched-color: #000099;
+    --matched-hover-color: #0011ff;
+    --line-hover-bg-color: #aaa;
+    &.theme-dark {
+        --matched-color: #e7d1b1;
+        --matched-hover-color: #ffc064;
+        --line-hover-bg-color: #555;
+    }
+}
+
+#cbi-window .window-content > form {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#cbi-top label {
+    flex: 0;
+    flex-basis: 80px;
+}
+
+#cbi-top .form-fields {
+    flex: 1;
+    justify-content: flex-start;
+}
+
+#cbi-main-button {
+    width: 97%;
+    height: 28px;
+}
+
+#cbi-bottom {
+    display: flex;
+    gap: 5px;
+}
+
+#cbi-import-text {
+    align-self: center;
+}
+
+#cbi-import-select {
+    width: 33%;
+    align-self: center;
+}
+
+#cbi-import-button {
+    width: 33%;
+    margin-left: auto;
+}
+
+#cbi-input {
+    margin-bottom: 5px;
+    overflow: auto;
+    border: 1px solid gray;
+    border-radius: 4px;
+    padding: 4px 8px;
+    white-space: pre-wrap;
+    flex: 1;
+    position: relative;
+}
+
+#cbi-input:empty::before {
+    content: attr(data-placeholder);
+    color: gray;
+}
+
+#cbi-input .block-container {
+    position: relative;
+    border-top: 1px solid rgba(128, 128, 128, 0.5);
+    padding: 8px 0;
+}
+
+#cbi-input .block-container::before {
+    content: attr(data-block-name);
+    position: absolute;
+    font-size: smaller;
+    font-weight: bold;
+    opacity: 0.5;
+    right: 0;
+    text-align: right;
+}
+
+#cbi-input .block-container.drag-over {
+    background-color: var(--line-hover-bg-color);
+}
+
+#cbi-input .line-container {
+    cursor: grab;
+}
+
+#cbi-input .line-container:hover {
+    background-color: var(--line-hover-bg-color);
+}
+
+#cbi-input span.hint::before {
+    content: 'Hint: ' attr(data-block-name);
+    font-size: smaller;
+    font-weight: bold;
+    opacity: 0.5;
+    margin: 8px;
+    border: 1px solid grey;
+    border-radius: 4px;
+    padding: 0 4px;
+    cursor: pointer;
+}
+
+#cbi-input span {
+    position: relative;
+    cursor: text;
+}
+
+#cbi-input span span.matched {
+    display: inline;
+    text-decoration: underline;
+    color: var(--matched-color);
+}
+
+#cbi-input span span.matched:hover {
+    color: var(--matched-hover-color);
+}
+
+#cbi-tooltip {
+    visibility: hidden;
+    min-width: 120px;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 6px 8px;
+    position: absolute;
+}
+
+#cbi-tooltip::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 100%;
+    margin-top: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent black transparent transparent;
+}
+
+#cbi-compendium-options-menu {
+    .container {
+        display: flex;
+        & > * {
+            flex: 1;
+        }
+    }
+    footer {
+        display: flex;
+    }
+}
+
+.cbi-issue {
+    border: 1px solid var(--color-level-warning);
+    border-radius: 4px;
+    background: rgba(214, 150, 0, 0.8);
+    margin: 4px 0;
+    padding: 4px;
+    a {
+        text-decoration: underline;
+    }
+}
+
+#cbi-compendium-options-menu .form-group label:hover {
+    cursor: move;
+}
+
+.cbi-dialog .line-text {
+    display: block;
+    font-style: italic;
+}

--- a/templates/cbiCompendiumOptions.hbs
+++ b/templates/cbiCompendiumOptions.hbs
@@ -1,0 +1,28 @@
+<div class="container">
+    <div>
+        <h3>Spell Compendiums</h3>
+        <ul id="cbi-spell-compendiums">
+            {{#each compendiums.spells}}
+                <li class="form-group">
+                    <label>
+                        <input type="checkbox" data-id="{{collection}}" {{#if active}}checked{{/if}} {{#if disabled}}disabled{{/if}} />
+                        {{title}}
+                    </label>
+                </li>
+            {{/each}}
+        </ul>
+    </div>
+    <div>
+        <h3>Item Compendiums</h3>
+        <ul id="cbi-item-compendiums">
+            {{#each compendiums.items}}
+                <li class="form-group">
+                    <label>
+                        <input type="checkbox" data-id="{{collection}}" {{#if active}}checked{{/if}} />
+                        {{title}}
+                    </label>
+                </li>
+            {{/each}}
+        </ul>
+    </div>
+</div>

--- a/templates/cbiCompendiumOptionsFooter.hbs
+++ b/templates/cbiCompendiumOptionsFooter.hbs
@@ -1,0 +1,2 @@
+<button type="button" data-action="cancel">Cancel</button>
+<button type="button" data-action="confirm">Confirm</button>

--- a/templates/cbiCompendiumOptionsHeader.hbs
+++ b/templates/cbiCompendiumOptionsHeader.hbs
@@ -1,0 +1,1 @@
+<p>Drag items to change priority. Higher priority compendiums will be searched first when looking up spells and items.</p>

--- a/templates/cbiWindow.hbs
+++ b/templates/cbiWindow.hbs
@@ -1,0 +1,24 @@
+<form class="standard-form">
+    <section id="cbi-top">
+        <div class="form-group">
+            <label for="cbi-import-autoparse">Auto parse:</label>
+            <div class="form-fields">
+                <input id="cbi-import-autoparse" type="checkbox" checked="checked" />
+                <button id="cbi-import-parse" type="button" data-action="parse">Parse</button>
+            </div>
+            <button id="cbi-import-reset" type="button" data-action="reset">Reset</button>
+        </div>
+    </section>
+    <div id="cbi-input" contenteditable="true" data-placeholder="Usage:
+- Paste the full class description text into this box. It should follow D&D 5e formatting to be imported correctly. Markdown is supported too.
+- You can click on the &quot;Parse&quot; button above to preview all the information that the module is able to parse from the text (the &quot;Auto Parse&quot; checkbox will automatically do that for you after every change).
+- If you need to, you can edit the text here to fix any errors. The &quot;Import&quot; button below will parse and create the class based on the current text.
+
+Report any bugs using the module link, and add the class description you were trying to import."></div>
+    <section id="cbi-issues"></section>
+    <section id="cbi-bottom">
+        <span id="cbi-import-text">Folder to import to:</span>
+        <select id="cbi-import-select"></select>
+        <button id="cbi-import-button" type="button" data-action="import">Import</button>
+    </section>
+</form>


### PR DESCRIPTION
This commit adds a complete class importer module that follows the same architecture and UI design as the statblock importer:

New Files:
- scripts/cbi.js - Main entry point, adds "Import Class" button to Items directory
- scripts/cbiConfig.js - Configuration and settings management
- scripts/cbiData.js - Data models and block definitions for class data
- scripts/cbiRegex.js - Regular expressions for parsing class descriptions
- scripts/cbiParser.js - Parser logic to extract class data from text
- scripts/cbiActor.js - Class data model and Foundry VTT integration
- scripts/cbiUtils.js - Utility functions for text processing and conversions
- scripts/cbiWindow.js - UI window component with parse/import functionality
- styles/cbi.css - Styling matching the statblock importer
- templates/cbiWindow.hbs - Main window template
- templates/cbiCompendiumOptions.hbs - Compendium settings template
- templates/cbiCompendiumOptionsHeader.hbs - Header template
- templates/cbiCompendiumOptionsFooter.hbs - Footer template

Features:
- Parses class descriptions including levels, features, proficiencies, and spells
- Visual preview with block grouping before import
- Creates D&D 5e class items in Foundry VTT
- Same UI/UX as the statblock importer for consistency
- Compendium integration for spell and item lookups
- Debug mode and issue tracking